### PR TITLE
streamline CFP approval and tracking process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 This directory contains CFP design proposals for features impacting repos across the
-Cilium Github organization.
+Cilium Github organization. 
+
+All current CFPs are listed in the [Cilium Feature Proposals (CFPs) project]() found in this repository.
 
 # Purpose of CFPs
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ accept.
 To create a CFP, it is recommended to use the `CFP-003-template.md`
 file as an outline. The structure of this template is meant to provide a starting
 point for people. Feel free to edit and modify your outline to best fit your
-needs when creating a proposal. When are you ready to submit your CFP please:
+needs when creating a proposal. When you are ready to submit your CFP please:
 
 1. Create a CFP issue in the repo your design applies to if you haven't already
 2. Create the file in this repo, with a path of `<repo>/CFP-###-subject.md` where the number is the CFP issue number
@@ -35,7 +35,7 @@ Many design docs also begin their life as a Google doc or other shareable
 file for easy commenting and editing when still in the early stages of discussion.
 Once your proposal is done, submit it as a PR to the design-cfps folder.
 
-If you want to bring further attention to your design, you may want to
+You are encouraged to share your PR in the [appropriate SIG slack channel](https://docs.cilium.io/en/stable/community/community/#all-sigs) to speed up the approval process. If you want to bring further attention to your design, you may want to
 raise the design during the [weekly community call](https://docs.cilium.io/en/v1.13/community/community/#id1)
 and on the [#development channel in Slack](https://cilium.slack.com/archives/C2B917YHE).
 
@@ -56,3 +56,14 @@ to reflect these differences.
 The code and our documentation are the ultimate sources of truth. CFPs are merely
 the starting point for the implementation.
 
+# Status
+
+ The status of a CFP indicates where it is in the process. The CFP process is as follows:
+
+ 1. ``Provisional``: All new PRs are given this status. This CFP's design has not yet been approved.
+ 2. ``Implementable``: Approved PRs that are merged are given this status. Their CFP design has been approved, and now the work can be started to implement them.
+ 3. ``Experimental``: The CFP has been implemented and is now in a 'Beta' state.
+ 4. ``Stable``: The CFP has been implemented, rigororously tested, and is now in a 'GA' state.
+ 5. ``Complete``: All implementation work is complete and has been merged.
+
+ At any time during the process, the CFP can be given the status of ``Withdrawn`` if it is no longer thought to be viable, or if it is not wanted to be pursued for any other reason.

--- a/cfps/CFP-003-template.md
+++ b/cfps/CFP-003-template.md
@@ -1,6 +1,6 @@
 # CFP-003: Template
 
-**SIG: SIG-NAME**
+**SIG: SIG-NAME ([View all current SIGs](https://docs.cilium.io/en/stable/community/community/#all-sigs))**
 
 **Begin Design Discussion:** YYYY-MM-DD
 


### PR DESCRIPTION
Inspired by the [Gateway Enhancement Proposal (GEP) docs](https://gateway-api.sigs.k8s.io/geps/overview/#process).

I tried to combine @joestringer's comment in https://github.com/cilium/design-cfps/issues/4 with the three proposed states in that same issue, resulting in 6 possible statuses (I renamed 'State' to 'Status' just to fit the default for GitHub Projects).``Experimental`` and ``Stable`` could use some stronger definitions, but I think the other four make sense.

These statuses will be listed in the [Cilium Feature Proposals (CFP) GitHub Project](https://github.com/users/katiestruthers/projects/4/views/1) that will be added to this repository. Workflows are set to automatically set Provisional (when a new PR is opened), Implementable (when a PR is merged), and Withdrawn (when a PR is closed), but the other three statuses will have to be manually set. The SIGs will also have to be manually set.

I have also opened a [PR to update the list of SIGs](https://github.com/cilium/cilium/pull/32477), so those links I added  will be more useful soon.